### PR TITLE
CHORE-macOS-automate-symbolic-linking-support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,5 @@ crashlytics-build.properties
 [Aa]ssets[Ss]treamingAssets/aa.meta
 [Aa]ssets[Ss]treamingAssets/aa/*
 
-# Assets folder content except the main resources folder.
-CST Unity Shared Resources/Assets/*
-!CST Unity Shared Resources/Assets/0_CstSharedResources/
-!CST Unity Shared Resources/Assets/0_CstSharedResources.meta
+# macOS folder attribute
+.DS_Store

--- a/mac_link.sh
+++ b/mac_link.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# === Get the directory of this script ===
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# === Prompt for project name ===
+read -p "Enter the project name: " PROJECT_NAME
+
+# === Configuration ===
+TARGET_FOLDER="$SCRIPT_DIR/../$PROJECT_NAME/Assets"
+LINK_NAME="0_CstSharedResources"
+LINK_TARGET="$SCRIPT_DIR/$LINK_NAME"
+
+# === Change to the target folder ===
+if [ ! -d "$TARGET_FOLDER" ]; then
+  echo "[Error] Target folder does not exist: $TARGET_FOLDER"
+  read -n 1 -s -r -p "Press any key to exit..."
+  echo
+  exit 1
+fi
+cd "$TARGET_FOLDER" || exit 1
+
+# === Remove old symlink if it exists ===
+if [ -L "$LINK_NAME" ] || [ -d "$LINK_NAME" ]; then
+  echo "Removing old symbolic link: $LINK_NAME"
+  rm -rf "$LINK_NAME"
+fi
+
+# === Create new symbolic link ===
+ln -s "$LINK_TARGET" "$LINK_NAME"
+if [ $? -eq 0 ]; then
+  echo "[Success] Symbolic link created: $LINK_NAME -> $LINK_TARGET"
+else
+  echo "[Error] Failed to create symbolic link."
+fi
+
+# === Pause before exit ===
+read -n 1 -s -r -p "Press any key to exit..."
+echo


### PR DESCRIPTION
### New features:

- Add a shell script `mac_link.sh` to automatically link this Submodule's main folder to the current Unity project on macOS.

### Chores:

- Update `.gitignore` file to exclude all macOS folder attribute hidden files `.DS_Store`.