### PR TITLE
REFACTOR-general-script-refactoring-phase-1

### DIFF
--- a/0_CstSharedResources/Prefabs/System/Audio Manager.prefab
+++ b/0_CstSharedResources/Prefabs/System/Audio Manager.prefab
@@ -50,11 +50,11 @@ MonoBehaviour:
   mixerGroupMaps:
     _serializedList:
     - Key: 0
-      Value: {fileID: 0}
+      Value: {fileID: 6078816342833185485, guid: b2a03e74dce045b49b7cb27623bd2174, type: 2}
     - Key: 1
-      Value: {fileID: 0}
+      Value: {fileID: 6406860560766586965, guid: b2a03e74dce045b49b7cb27623bd2174, type: 2}
     - Key: 2
-      Value: {fileID: 0}
+      Value: {fileID: 9086080056508771514, guid: b2a03e74dce045b49b7cb27623bd2174, type: 2}
   audioEntries: []
 --- !u!1 &1334499020120075185
 GameObject:

--- a/0_CstSharedResources/Runtime/Scripts/Environment/Interactable.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Environment/Interactable.cs
@@ -69,7 +69,7 @@ namespace CST.Shared.Resources
 
 			_mat.SetFloat("_Thickness", .4f);
 
-			if (LegacyInputManager.Instance.GetKeyDown(KeybindingActions.Interact))
+			if (LegacyInputManager.Instance.GetKeyDown(KeybindingAction.Interact))
 				Interact();
 
 			// TODO - derived classes implement their own way to visualize interaction.

--- a/0_CstSharedResources/Runtime/Scripts/Input Systems/KeybindingAction.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Input Systems/KeybindingAction.cs
@@ -1,0 +1,31 @@
+namespace CST.Shared.Resources
+{
+	public enum KeybindingAction
+	{
+		Attack = 0,
+		ToggleAimMode = 1,
+		Aiming = 2,
+		MoveLeft = 3,
+		MoveRight = 4,
+		MoveUp = 5,
+		MoveDown = 6,
+		Movement = 7,
+		Jump = 13,
+		ContinueDialogue = 8,
+		OpenInventory = 15,
+		Interact = 9,
+		Reload = 10,
+		Mining = 14,
+		BackToMenu = 11,
+		SkipPlayable = 12
+	}
+
+	public enum MouseButtonType
+	{
+		Left,
+		Right,
+		Middle,
+		Forward,
+		Backward
+	}
+}

--- a/0_CstSharedResources/Runtime/Scripts/Input Systems/KeybindingAction.cs.meta
+++ b/0_CstSharedResources/Runtime/Scripts/Input Systems/KeybindingAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6adbd9d61efa20445ab37b0c43e9e24f

--- a/0_CstSharedResources/Runtime/Scripts/Input Systems/Keyset.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Input Systems/Keyset.cs
@@ -10,42 +10,15 @@ namespace CST.Shared.Resources
 	public class Keyset : ScriptableObject
 	{
 		[Header("List of keys"), Space]
-		public SerializedDictionary<KeybindingActions, KeyCode> keyTable = new SerializedDictionary<KeybindingActions, KeyCode>();
+		public SerializedDictionary<KeybindingAction, KeyCode> keyTable = new SerializedDictionary<KeybindingAction, KeyCode>();
 
 		public int TotalKeys => keyTable.Count;
 		public int LastIndex => TotalKeys - 1;
 
-		public KeyCode this[KeybindingActions action]
+		public KeyCode this[KeybindingAction action]
 		{
 			get { return keyTable[action]; }
 			set { keyTable[action] = value; }
 		}
-	}
-
-	public enum KeybindingActions
-	{
-		Attack = 0,
-		ToggleAimMode = 1,
-		Aiming = 2,
-		MoveLeft = 3,
-		MoveRight = 4,
-		MoveUp = 5,
-		MoveDown = 6,
-		Movement = 7,
-		Jump = 13,
-		ContinueDialogue = 8,
-		Interact = 9,
-		Reload = 10,
-		BackToMenu = 11,
-		SkipPlayable = 12
-	}
-
-	public enum MouseButtonType
-	{
-		Left,
-		Right,
-		Middle,
-		Forward,
-		Backward
 	}
 }

--- a/0_CstSharedResources/Runtime/Scripts/Input Systems/LegacyInputManager.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Input Systems/LegacyInputManager.cs
@@ -12,7 +12,7 @@ namespace CST.Shared.Resources
 		[Header("Keyset Reference"), Space]
 		[SerializeField] private Keyset keySet;
 
-		public KeyCode GetKeyForAction(KeybindingActions action)
+		public KeyCode GetKeyForAction(KeybindingAction action)
 		{
 			return keySet[action];
 		}
@@ -22,7 +22,7 @@ namespace CST.Shared.Resources
 		/// </summary>
 		/// <param name="action"></param>
 		/// <returns></returns>
-		public bool GetKey(KeybindingActions action)
+		public bool GetKey(KeybindingAction action)
 		{
 			KeyCode keyCode = GetKeyForAction(action);
 			bool result = Input.GetKey(keyCode);
@@ -35,7 +35,7 @@ namespace CST.Shared.Resources
 		/// </summary>
 		/// <param name="action"></param>
 		/// <returns></returns>
-		public bool GetKeyDown(KeybindingActions action)
+		public bool GetKeyDown(KeybindingAction action)
 		{
 			KeyCode keyCode = GetKeyForAction(action);
 			//Debug.Log(keyCode);
@@ -49,7 +49,7 @@ namespace CST.Shared.Resources
 		/// </summary>
 		/// <param name="action"></param>
 		/// <returns></returns>
-		public bool GetKeyUp(KeybindingActions action)
+		public bool GetKeyUp(KeybindingAction action)
 		{
 			KeyCode keyCode = GetKeyForAction(action);
 			bool result = Input.GetKeyUp(keyCode);
@@ -69,20 +69,20 @@ namespace CST.Shared.Resources
 			switch (axis)
 			{
 				case "horizontal":
-					if (GetKey(KeybindingActions.MoveRight))
+					if (GetKey(KeybindingAction.MoveRight))
 						return 1f;
 
-					else if (GetKey(KeybindingActions.MoveLeft))
+					else if (GetKey(KeybindingAction.MoveLeft))
 						return -1f;
 
 					else
 						return 0f;
 
 				case "vertical":
-					if (GetKey(KeybindingActions.MoveUp))
+					if (GetKey(KeybindingAction.MoveUp))
 						return 1f;
 
-					else if (GetKey(KeybindingActions.MoveDown))
+					else if (GetKey(KeybindingAction.MoveDown))
 						return -1f;
 
 					else

--- a/0_CstSharedResources/Runtime/Scripts/Player Movements/PlatformerPlayerController.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Player Movements/PlatformerPlayerController.cs
@@ -89,8 +89,8 @@ namespace CST.Shared.Resources
 			_frameInput.direction = NewInputManager.Instance.ReadValue<Vector2>(KeybindingActions.Movement);
 
 #elif ENABLE_LEGACY_INPUT_MANAGER
-			_frameInput.jumpPressedDown = LegacyInputManager.Instance.GetKeyDown(KeybindingActions.Jump);
-			_frameInput.jumpHeld = LegacyInputManager.Instance.GetKey(KeybindingActions.Jump);
+			_frameInput.jumpPressedDown = LegacyInputManager.Instance.GetKeyDown(KeybindingAction.Jump);
+			_frameInput.jumpHeld = LegacyInputManager.Instance.GetKey(KeybindingAction.Jump);
 
 			_frameInput.direction.x = LegacyInputManager.Instance.GetAxisRaw("Horizontal");
 			_frameInput.direction.y = LegacyInputManager.Instance.GetAxisRaw("Vertical");

--- a/0_CstSharedResources/Runtime/Scripts/Player Movements/TopDownPlayerController.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Player Movements/TopDownPlayerController.cs
@@ -25,7 +25,7 @@ namespace CST.Shared.Resources
 
 		private void Start()
 		{
-			_maxSpeed = stats.GetDynamicStat(Stat.MoveSpeed);
+			_maxSpeed = stats.GetDynamicStat(StatType.MoveSpeed);
 		}
 
 		private void Update()
@@ -47,7 +47,7 @@ namespace CST.Shared.Resources
 		{
 			if (type == typeof(StatsUpgrade))
 			{
-				_maxSpeed = stats.GetDynamicStat(Stat.MoveSpeed);
+				_maxSpeed = stats.GetDynamicStat(StatType.MoveSpeed);
 			}
 		}
 

--- a/0_CstSharedResources/Runtime/Scripts/Projectiles 2D/ProjectileBase.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Projectiles 2D/ProjectileBase.cs
@@ -74,9 +74,9 @@ namespace CST.Shared.Resources
 
 			SetTarget(trackTarget);
 
-			flySpeed = _shooterStats.GetStaticStat(Stat.ProjectileSpeed);
-			trackingRigidity = _shooterStats.GetStaticStat(Stat.ProjectileTrackingRigidity);
-			maxLifeTime = _shooterStats.GetStaticStat(Stat.ProjectileLifeTime);
+			flySpeed = _shooterStats.GetStaticStat(StatType.ProjectileSpeed);
+			trackingRigidity = _shooterStats.GetStaticStat(StatType.ProjectileTrackingRigidity);
+			maxLifeTime = _shooterStats.GetStaticStat(StatType.ProjectileLifeTime);
 
 			_aliveTime = maxLifeTime;
 		}

--- a/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/StatType.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/StatType.cs
@@ -1,0 +1,63 @@
+namespace CST.Shared.Resources
+{
+	public enum StatType
+	{
+		// Dynamic stats.
+
+		/// <summary>
+		/// Maximum health of the character.
+		/// </summary>
+		MaxHealth = 0,
+
+		/// <summary>
+		/// How much damage does the character deal per hit?
+		/// </summary>
+		Damage = 1,
+
+		/// <summary>
+		/// How many attacks can the character do per second?
+		/// </summary>
+		AttackSpeed = 2,
+
+		/// <summary>
+		/// How fast does the character move? In unit/s
+		/// </summary>
+		MoveSpeed = 3,
+		
+		/// <summary>
+		/// How quick does the character change its moving direction? In deg/s
+		/// </summary>
+		TurnAngleDegree = 10,
+
+		/// <summary>
+		/// For how long is the character invincible after taking damage? In seconds.
+		/// </summary>
+		InvincibilityTime = 4,
+
+		// Static stats.
+		/// <summary>
+		/// How strong is the knockback force applied to other objects when this character hits them?
+		/// </summary>
+		KnockBackStrength = 5,
+
+		/// <summary>
+		/// How strong does the character resist knockback forces? In scale of 0-1.
+		/// </summary>
+		KnockBackResistant = 6,
+
+		/// <summary>
+		/// How fast do projectiles fired by this character move? In unit/s
+		/// </summary>
+		ProjectileSpeed = 7,
+
+		/// <summary>
+		/// How quickly do projectiles adjust their direction towards the target? Higher values means more rigid tracking.
+		/// </summary>
+		ProjectileTrackingRigidity = 8,
+
+		/// <summary>
+		/// How long do projectiles fired by this character last before disappearing? In seconds.
+		/// </summary>
+		ProjectileLifeTime = 9
+	}
+}

--- a/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/StatType.cs.meta
+++ b/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/StatType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: faf88d941ce2df1459c7fb283dbd8e5d

--- a/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/Stats.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/Stats.cs
@@ -9,19 +9,19 @@ namespace CST.Shared.Resources
 	{
 		[Header("Stats"), Space]
 		[Tooltip("Dynamic stats are GLOBAL stats shared between objects, which CAN be modified by upgrades.")]
-		public SerializedDictionary<Stat, float> dynamicStats = new SerializedDictionary<Stat, float>();
+		public SerializedDictionary<StatType, float> dynamicStats = new SerializedDictionary<StatType, float>();
 
 		[Tooltip("Static stats are GLOBAL stats shared between objects, which CAN NOT be modified by upgrades.")]
-		public SerializedDictionary<Stat, float> staticStats = new SerializedDictionary<Stat, float>();
+		public SerializedDictionary<StatType, float> staticStats = new SerializedDictionary<StatType, float>();
 
 		// Private fields.
 		private readonly HashSet<StatsUpgrade> _appliedUpgrades = new HashSet<StatsUpgrade>();
-		private readonly HashSet<Stat> _toStringIgnoreStats = new HashSet<Stat>()
+		private readonly HashSet<StatType> _toStringIgnoreStats = new HashSet<StatType>()
 	{
-		Stat.InvincibilityTime,
-		Stat.ProjectileSpeed,
-		Stat.ProjectileLifeTime,
-		Stat.ProjectileTrackingRigidity,
+		StatType.InvincibilityTime,
+		StatType.ProjectileSpeed,
+		StatType.ProjectileLifeTime,
+		StatType.ProjectileTrackingRigidity,
 	};
 
 		public void AddUpgrade(StatsUpgrade upgrade)
@@ -40,7 +40,7 @@ namespace CST.Shared.Resources
 			_appliedUpgrades.Clear();
 		}
 
-		public float GetStaticStat(Stat statName)
+		public float GetStaticStat(StatType statName)
 		{
 			if (staticStats.TryGetValue(statName, out float value))
 				return value;
@@ -52,7 +52,7 @@ namespace CST.Shared.Resources
 			}
 		}
 
-		public float GetDynamicStat(Stat statName)
+		public float GetDynamicStat(StatType statName)
 		{
 			if (dynamicStats.TryGetValue(statName, out float baseValue))
 				return GetUpgradedValue(statName, baseValue);
@@ -64,7 +64,7 @@ namespace CST.Shared.Resources
 			}
 		}
 
-		public void ModifyStat(Stat statName, float delta)
+		public void ModifyStat(StatType statName, float delta)
 		{
 			if (dynamicStats.TryGetValue(statName, out float _))
 			{
@@ -76,7 +76,7 @@ namespace CST.Shared.Resources
 			}
 		}
 
-		private float GetUpgradedValue(Stat stat, float baseValue)
+		private float GetUpgradedValue(StatType stat, float baseValue)
 		{
 			foreach (StatsUpgrade upgrade in _appliedUpgrades)
 			{
@@ -95,35 +95,18 @@ namespace CST.Shared.Resources
 		public override string ToString()
 		{
 			string result = "";
-			foreach (KeyValuePair<Stat, float> stat in dynamicStats)
+			foreach (KeyValuePair<StatType, float> stat in dynamicStats)
 			{
 				if (!_toStringIgnoreStats.Contains(stat.Key))
 					result += $"{stat.Key.ToString().AddWhitespaceBeforeCapital()}: {stat.Value}\n";
 			}
 			result += "\n";
-			foreach (KeyValuePair<Stat, float> stat in staticStats)
+			foreach (KeyValuePair<StatType, float> stat in staticStats)
 			{
 				if (!_toStringIgnoreStats.Contains(stat.Key))
 					result += $"{stat.Key.ToString().AddWhitespaceBeforeCapital()}: {stat.Value}\n";
 			}
 			return result.TrimEnd('\r', '\n');
 		}
-	}
-
-	public enum Stat
-	{
-		// Dynamic.
-		MaxHealth,
-		Damage,
-		AttackSpeed,
-		MoveSpeed,
-		InvincibilityTime,
-
-		// Static.
-		KnockBackStrength,
-		KnockBackRes,
-		ProjectileSpeed,
-		ProjectileTrackingRigidity,
-		ProjectileLifeTime
 	}
 }

--- a/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/Upgrades/StatsUpgrade.cs
+++ b/0_CstSharedResources/Runtime/Scripts/Scriptable Objects/Stats/Upgrades/StatsUpgrade.cs
@@ -7,7 +7,7 @@ namespace CST.Shared.Resources
 	public class StatsUpgrade : GenericUpgradeBase<Stats>
 	{
 		[Header("Detail"), Space]
-		public SerializedDictionary<Stat, float> affectedStats = new SerializedDictionary<Stat, float>();
+		public SerializedDictionary<StatType, float> affectedStats = new SerializedDictionary<StatType, float>();
 
 		public override void DoUpgrade()
 		{

--- a/0_CstSharedResources/Runtime/Scripts/UI/Elements/InteractionPopupLabel.cs
+++ b/0_CstSharedResources/Runtime/Scripts/UI/Elements/InteractionPopupLabel.cs
@@ -47,7 +47,7 @@ namespace CST.Shared.Resources
 		keyboardCue.text = NewInputManager.Instance.GetDisplayString(KeybindingActions.Interact);
 		
 #elif ENABLE_LEGACY_INPUT_MANAGER
-			keyboardCue.text = LegacyInputManager.Instance.GetKeyForAction(KeybindingActions.Interact).ToString();
+			keyboardCue.text = LegacyInputManager.Instance.GetKeyForAction(KeybindingAction.Interact).ToString();
 #endif
 
 			switch (inputSource)

--- a/0_CstSharedResources/Runtime/Scripts/UI/Health Bars/Regular/RegularHealthBar.cs
+++ b/0_CstSharedResources/Runtime/Scripts/UI/Health Bars/Regular/RegularHealthBar.cs
@@ -39,7 +39,7 @@ namespace CST.Shared.Resources
 
 		private void Start()
 		{
-			SetMaxHealth(stats.GetDynamicStat(Stat.MaxHealth));
+			SetMaxHealth(stats.GetDynamicStat(StatType.MaxHealth));
 		}
 
 		public void Accept(IVisitor visitor)


### PR DESCRIPTION
### Refactors:

- Rename the `KeybindingAction` enum's name to singular noun, and move it along with the `MouseButtonType` to a separate file.
- Rename the `Stat` enum to `StatType` and move it to a separate file, add summary for each enum value.

### Chores:

- Reference the main __audio mixer__ to pre-defined mixer group maps in the `AudioManager` prefab.